### PR TITLE
Bumping servant bounds to support 0.18

### DIFF
--- a/servant-cassava.cabal
+++ b/servant-cassava.cabal
@@ -34,7 +34,7 @@ library
                      , base-compat >=0.9.1 && <0.12
                      , bytestring
                      , cassava >=0.4.3 && <0.6
-                     , servant >=0.7 && <0.18
+                     , servant >=0.7 && <0.19
                      , http-media
                      , vector
   hs-source-dirs:      src
@@ -55,7 +55,7 @@ test-suite example
     , servant
     , cassava
     , servant-cassava
-    , servant-server >=0.4.4.5  && <0.18
+    , servant-server >=0.4.4.5  && <0.19
     , wai            >=3.0.3.0  && <3.3
     , warp           >=3.0.13.1 && <3.4
   default-language: Haskell2010


### PR DESCRIPTION
I tested this with stackage lts-17.1, which has servant 0.18.2 in it. Everything built fine 👍🏻 