### PR TITLE
Allow Servant version 0.19

### DIFF
--- a/servant-cassava.cabal
+++ b/servant-cassava.cabal
@@ -33,7 +33,7 @@ library
                      , base-compat >=0.9.1 && <0.12
                      , bytestring
                      , cassava >=0.4.3 && <0.6
-                     , servant >=0.7 && <0.19
+                     , servant >=0.7 && <0.20
                      , http-media
                      , vector
   hs-source-dirs:      src
@@ -54,7 +54,7 @@ test-suite example
     , servant
     , cassava
     , servant-cassava
-    , servant-server >=0.4.4.5  && <0.19
+    , servant-server >=0.4.4.5  && <0.20
     , wai            >=3.0.3.0  && <3.3
     , warp           >=3.0.13.1 && <3.4
   default-language: Haskell2010


### PR DESCRIPTION
Tested using

    cabal test --constraint='servant>=0.19' -w ghc-9.0.2
