### PR TITLE
remove `x-revision` from `.cabal` file

### DIFF
--- a/servant-cassava.cabal
+++ b/servant-cassava.cabal
@@ -1,7 +1,6 @@
 cabal-version:       >=1.10
 name:                servant-cassava
 version:             0.10.2
-x-revision:          7
 
 synopsis:            Servant CSV content-type for cassava
 category:            Servant, Web, CSV


### PR DESCRIPTION
The currently released version of servant-cassava (0.10.2) doesn't have any revisions on hackage:

https://hackage.haskell.org/package/servant-cassava-0.10.2/revisions/

Alternatively, I could have probably set `x-revision` to `0`.