### PR TITLE
Bump the base-compat dependency upper bound

### DIFF
--- a/servant-cassava.cabal
+++ b/servant-cassava.cabal
@@ -29,7 +29,7 @@ source-repository head
 library
   exposed-modules:     Servant.CSV.Cassava
   build-depends:       base >=4.7 && <5
-                     , base-compat >=0.9.1 && <0.13
+                     , base-compat >=0.9.1 && <0.14
                      , bytestring
                      , cassava >=0.4.3 && <0.6
                      , servant >=0.7 && <0.21


### PR DESCRIPTION
This just bumps the upper bound on the `base-compat` dependency, supporting the version in Stackage LTS 22